### PR TITLE
Wildcard not allowed for graft command

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-graft *
+graft .
 prune .hg
 prune .hgignore
 prune .ropeproject


### PR DESCRIPTION
This fixes this problem:

        reading manifest file 'pip-egg-info/django_smart_selects.egg-info/SOURCES.txt'
        reading manifest template 'MANIFEST.in'
        error: [Errno 2] No such file or directory: '*'

 with the manifest file while running setup tools. According to the [docs](https://docs.python.org/2/distutils/sourcedist.html#manifest-template), the value for ```graft``` should be a directory and not a pattern. This seems to be true for Python 3.x also, though it isn't mentioned in the docs anymore.